### PR TITLE
fix: suppress CSS parsing errors from JSDOM operations

### DIFF
--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,6 +1,26 @@
 import { extract } from '@extractus/article-extractor';
 import { JSDOM } from 'jsdom';
 
+function suppressConsole<T>(fn: () => T): T {
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  
+  // Suppress console output during JSDOM operations
+  console.error = () => {};
+  console.warn = () => {};
+  console.log = () => {};
+  
+  try {
+    return fn();
+  } finally {
+    // Restore original console methods
+    console.error = originalError;
+    console.warn = originalWarn;
+    console.log = originalLog;
+  }
+}
+
 interface ExtractedContent {
   title: string;
   content: string;
@@ -8,7 +28,7 @@ interface ExtractedContent {
 }
 
 function extractArticleHtml(html: string): string {
-  const dom = new JSDOM(html);
+  const dom = suppressConsole(() => new JSDOM(html));
   const document = dom.window.document;
   
   // Remove script, style, and other non-content elements
@@ -124,7 +144,7 @@ export async function extractTextContent(html: string): Promise<ExtractedContent
     
     if (article?.content && article.content.length > 100) {
       // Clean up the content by removing HTML tags
-      const dom = new JSDOM(article.content);
+      const dom = suppressConsole(() => new JSDOM(article.content));
       const textContent = dom.window.document.body.textContent || '';
       
       // Apply content cleaning
@@ -143,7 +163,7 @@ export async function extractTextContent(html: string): Promise<ExtractedContent
   }
 
   // Fallback to basic extraction
-  const dom = new JSDOM(html);
+  const dom = suppressConsole(() => new JSDOM(html));
   const document = dom.window.document;
   
   // Extract title

--- a/src/thumbnailExtractor.ts
+++ b/src/thumbnailExtractor.ts
@@ -1,5 +1,25 @@
 import { JSDOM } from 'jsdom';
 
+function suppressConsole<T>(fn: () => T): T {
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  
+  // Suppress console output during JSDOM operations
+  console.error = () => {};
+  console.warn = () => {};
+  console.log = () => {};
+  
+  try {
+    return fn();
+  } finally {
+    // Restore original console methods
+    console.error = originalError;
+    console.warn = originalWarn;
+    console.log = originalLog;
+  }
+}
+
 interface ImageCandidate {
   url: string;
   width?: number;
@@ -79,7 +99,7 @@ function filterUnwantedImages(images: ImageCandidate[]): ImageCandidate[] {
 }
 
 function extractImagesFromHtml(html: string, baseUrl: string): ImageCandidate[] {
-  const dom = new JSDOM(html);
+  const dom = suppressConsole(() => new JSDOM(html));
   const document = dom.window.document;
   const images: ImageCandidate[] = [];
   


### PR DESCRIPTION
Fixes #1

## Summary
- Add suppressConsole wrapper to temporarily suppress console output during JSDOM operations
- Apply to all JSDOM instantiations in extractor.ts and thumbnailExtractor.ts
- Fixes issue where "Could not parse CSS stylesheet" errors were logged even though processing continues correctly

## Test Plan
- Run the tool on websites with malformed CSS
- Verify that CSS parsing errors no longer appear in logs
- Verify that article extraction and processing still works correctly

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTML解析時に発生する不要なコンソール出力（エラーや警告など）が自動的に抑制されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->