### PR TITLE
feat: add date prefix option for filename format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ async function main() {
     .argument('[urls...]', 'summarize articles from the provided URLs (supports multiple URLs)')
     .option('--config', 'configure API key')
     .option('-w, --watch', 'start in watch mode for continuous URL input')
+    .option('-d, --date-prefix', 'add date prefix to filename (YYYY-MM-DD_title.md format)')
     .parse();
 
   const options = program.opts();
@@ -37,7 +38,7 @@ async function main() {
     }
 
     if (options.watch) {
-      await startWatchMode();
+      await startWatchMode(options.datePrefix);
       return;
     }
 
@@ -76,7 +77,7 @@ async function main() {
           const { summary, details, translatedTitle, tags, validImageUrl } = await summarizeContent(title, htmlContent, extractedUrl);
           
           console.log(chalk.gray('  💾 マークダウンファイルに保存中...'));
-          const filename = await saveToMarkdown(translatedTitle, extractedUrl, summary, details, tags, validImageUrl);
+          const filename = await saveToMarkdown(translatedTitle, extractedUrl, summary, details, tags, validImageUrl, options.datePrefix);
           
           console.log(chalk.green(`  ✅ 完了: ${filename}\n`));
           return { success: true, filename, url };

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -7,7 +7,8 @@ export async function saveToMarkdown(
   summary: string,
   details: string,
   tags: string[],
-  imageUrl?: string
+  imageUrl?: string,
+  datePrefix?: boolean
 ): Promise<string> {
   // Format current date
   const now = new Date();
@@ -21,7 +22,9 @@ export async function saveToMarkdown(
     .slice(0, 100);                // Limit length
   
   // Create filename using translated title
-  const filename = `📰 ${cleanTitle}.md`;
+  const filename = datePrefix 
+    ? `${dateStr}_${cleanTitle}.md`
+    : `📰 ${cleanTitle}.md`;
   const filepath = join(process.cwd(), filename);
   
   // Format tags

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -4,7 +4,7 @@ import { fetchContent } from './fetcher.js';
 import { summarizeContent } from './summarizer.js';
 import { saveToMarkdown } from './markdown.js';
 
-export async function startWatchMode() {
+export async function startWatchMode(datePrefix?: boolean) {
   if (!config.hasApiKey()) {
     console.log('APIキーが設定されていません。最初に設定を行ってください。');
     await config.configure();
@@ -164,7 +164,7 @@ export async function startWatchMode() {
       const { summary, details, translatedTitle, tags, validImageUrl } = await summarizeContent(title, htmlContent, extractedUrl, true);
       
       addLog('  💾 マークダウンファイルに保存中...');
-      const filename = await saveToMarkdown(translatedTitle, extractedUrl, summary, details, tags, validImageUrl);
+      const filename = await saveToMarkdown(translatedTitle, extractedUrl, summary, details, tags, validImageUrl, datePrefix);
       
       addLog(`✅ 完了: ${filename}`);
     } catch (error) {


### PR DESCRIPTION
## Summary
- Add `-d, --date-prefix` CLI option to enable YYYY-MM-DD_title.md filename format
- Modify `saveToMarkdown` function to support date prefix parameter
- Update both regular and watch modes to pass date prefix option
- Maintain backward compatibility with existing emoji prefix format

## Test plan
- [ ] Test regular mode: `npm run dev -d https://example.com`
- [ ] Test watch mode: `npm run dev -w -d`
- [ ] Test multiple URLs: `npm run dev -d url1 url2`
- [ ] Verify backward compatibility without `-d` flag
- [ ] Check TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - CLIに`-d, --date-prefix`オプションを追加し、出力されるMarkdownファイル名の先頭に日付（YYYY-MM-DD形式）を付与できるようになりました。  
- **その他**
  - ファイル名のフォーマット選択が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->