### PR TITLE
feat: add emoji prefix to filenames when using date prefix option

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -22,7 +22,7 @@ export async function saveToMarkdown(
     .slice(0, 100); // Limit length
 
   // Create filename using translated title
-  const filename = datePrefix ? `${dateStr}_${cleanTitle}.md` : `📰 ${cleanTitle}.md`;
+  const filename = datePrefix ? `📰 ${dateStr}_${cleanTitle}.md` : `📰 ${cleanTitle}.md`;
   const filepath = join(process.cwd(), filename);
 
   // Format tags


### PR DESCRIPTION
## Summary
- Ensures the 📰 emoji is always included in output filenames
- Previously, using `-d` option would omit the emoji prefix
- Now both filename formats include the emoji for consistency

## Changes
- Modified `src/markdown.ts` to include emoji in date-prefixed filenames
- Without `-d`: `📰 Article_Title.md` (unchanged)
- With `-d`: `📰 2025-01-09_Article_Title.md` (now includes emoji)

## Test plan
- [x] Run `npm run lint` - passes without errors
- [x] Run `npm run build` - builds successfully
- [ ] Test with single URL without `-d` option
- [ ] Test with single URL with `-d` option
- [ ] Verify emoji appears in both filename formats

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Markdownファイルの保存時、ファイル名の先頭に常に「📰」絵文字が付与されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->