### PR TITLE
feat: add -s (simplify) option for summary-only output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ async function main() {
     .option('--config', 'configure API key')
     .option('-w, --watch', 'start in watch mode for continuous URL input')
     .option('-d, --date-prefix', 'add date prefix to filename (YYYY-MM-DD_title.md format)')
+    .option('-s, --simplify', 'output only 3-line summary without details')
     .parse();
 
   const options = program.opts();
@@ -38,7 +39,7 @@ async function main() {
     }
 
     if (options.watch) {
-      await startWatchMode(options.datePrefix);
+      await startWatchMode(options.datePrefix, options.simplify);
       return;
     }
 
@@ -77,7 +78,9 @@ async function main() {
           const { summary, details, translatedTitle, tags, validImageUrl } = await summarizeContent(
             title,
             htmlContent,
-            extractedUrl
+            extractedUrl,
+            false,
+            options.simplify
           );
 
           console.log(chalk.gray('  💾 マークダウンファイルに保存中...'));
@@ -88,7 +91,8 @@ async function main() {
             details,
             tags,
             validImageUrl,
-            options.datePrefix
+            options.datePrefix,
+            options.simplify
           );
 
           console.log(chalk.green(`  ✅ 完了: ${filename}\n`));

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -8,7 +8,8 @@ export async function saveToMarkdown(
   details: string,
   tags: string[],
   imageUrl?: string,
-  datePrefix?: boolean
+  datePrefix?: boolean,
+  simplify?: boolean
 ): Promise<string> {
   // Format current date
   const now = new Date();
@@ -35,7 +36,19 @@ export async function saveToMarkdown(
 `
     : '';
 
-  const markdownContent = `[${translatedTitle}](${url})
+  // Build markdown content based on simplify mode
+  const markdownContent = simplify
+    ? `[${translatedTitle}](${url})
+scrap at [[${dateStr}]]
+
+${imageSection}${tagString}
+
+## 3行まとめ
+${summary}
+
+#web_scrap
+`
+    : `[${translatedTitle}](${url})
 scrap at [[${dateStr}]]
 
 ${imageSection}${tagString}

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -344,7 +344,7 @@ export async function summarizeContent(
     }
     const { summary, translatedTitle, tags } = await generateCombinedSummaryData(title, truncatedContent, anthropic);
 
-    // Skip thumbnail extraction and details generation in simplify mode
+    // Skip details generation in simplify mode, but still extract thumbnail
     let validImageUrl: string | undefined;
     let details = '';
 

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -329,7 +329,8 @@ export async function summarizeContent(
   title: string,
   htmlContent: string,
   baseUrl: string,
-  isSilent = false
+  isSilent = false,
+  simplifyMode = false
 ): Promise<SummaryResult> {
   const apiKey = config.getApiKey();
   const anthropic = new Anthropic({ apiKey });
@@ -343,15 +344,24 @@ export async function summarizeContent(
     }
     const { summary, translatedTitle, tags } = await generateCombinedSummaryData(title, truncatedContent, anthropic);
 
-    if (!isSilent) {
-      console.log('    🔄 サムネイル画像を抽出中...');
-    }
-    const validImageUrl = extractThumbnailFromHtml(htmlContent, baseUrl);
+    // Skip thumbnail extraction and details generation in simplify mode
+    let validImageUrl: string | undefined;
+    let details = '';
 
-    if (!isSilent) {
-      console.log('    🔄 詳細を生成中...');
+    if (!simplifyMode) {
+      if (!isSilent) {
+        console.log('    🔄 サムネイル画像を抽出中...');
+      }
+      validImageUrl = extractThumbnailFromHtml(htmlContent, baseUrl);
+
+      if (!isSilent) {
+        console.log('    🔄 詳細を生成中...');
+      }
+      details = await generateDetails(title, truncatedContent, anthropic, baseUrl);
+    } else {
+      // Still extract thumbnail in simplify mode for better visual
+      validImageUrl = extractThumbnailFromHtml(htmlContent, baseUrl);
     }
-    const details = await generateDetails(title, truncatedContent, anthropic, baseUrl);
 
     return { summary, details, translatedTitle, tags, validImageUrl };
   } catch (error) {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -4,7 +4,7 @@ import { fetchContent } from './fetcher.js';
 import { summarizeContent } from './summarizer.js';
 import { saveToMarkdown } from './markdown.js';
 
-export async function startWatchMode(datePrefix?: boolean) {
+export async function startWatchMode(datePrefix?: boolean, simplify?: boolean) {
   if (!config.hasApiKey()) {
     console.log('APIキーが設定されていません。最初に設定を行ってください。');
     await config.configure();
@@ -164,7 +164,8 @@ export async function startWatchMode(datePrefix?: boolean) {
         title,
         htmlContent,
         extractedUrl,
-        true
+        true,
+        simplify
       );
 
       addLog('  💾 マークダウンファイルに保存中...');
@@ -175,7 +176,8 @@ export async function startWatchMode(datePrefix?: boolean) {
         details,
         tags,
         validImageUrl,
-        datePrefix
+        datePrefix,
+        simplify
       );
 
       addLog(`✅ 完了: ${filename}`);


### PR DESCRIPTION
## Summary
- Add new `-s, --simplify` command line option
- Skip details generation when simplify mode is enabled
- Support simplify mode in both normal and watch modes

## Changes
1. **CLI Option**: Added `-s, --simplify` flag to command line interface
2. **Markdown Output**: Modified to exclude "詳細" section when in simplify mode
3. **Performance**: Skip expensive detail generation API call in simplify mode
4. **Watch Mode Support**: Full compatibility with `-w` watch mode

## Usage Examples
```bash
# Normal mode with simplify
npm run dev -s https://example.com/article

# Watch mode with simplify
npm run dev -w -s

# Date prefix with simplify
npm run dev -d -s https://example.com/article
```

## Test Plan
- [ ] Test normal mode with `-s` flag
- [ ] Test watch mode with `-w -s` flags
- [ ] Verify markdown output excludes details section
- [ ] Confirm thumbnail is still extracted in simplify mode
- [ ] Test combination with date prefix option

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - CLIに -s / --simplify を追加し、要約の簡易出力を切り替え可能にしました。
  - 簡易モードでは詳細文の生成を省略し、要点のみのコンパクトなMarkdownを保存します。
  - 非簡易モードは従来どおり詳細を含むフル構成のMarkdownを出力します。
  - 画像、タグ、日付プレフィックスの挙動は従来どおり維持されます。
  - ウォッチモードでも簡易モードが有効になり、取得から保存まで一貫して適用されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->