### PR TITLE
fix(ci): grant contents write permission for version bump push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write  # git push (version bump) に必要
 
 jobs:
   publish:


### PR DESCRIPTION
## なぜやるか

Publish to npm CI が失敗していたため。

`publish.yml` の "Bump version if needed" ステップで `git push` を実行しているが、ワークフローの `permissions` に `contents: read` しか設定されておらず、push 時に権限エラーが発生していた。

## やったこと

`.github/workflows/publish.yml` の `contents` 権限を `read` → `write` に変更した。

## やってないこと

- その他のワークフロー設定の変更
- npm publish フローそのものの変更